### PR TITLE
Improve hero heading gradient compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,8 @@
     .hero-content { z-index: 2; opacity: 0; transform: translateY(50px); animation: fadeInUp 1s ease 0.5s forwards; }
     @keyframes fadeInUp { to { opacity: 1; transform: translateY(0); } }
     .hero h1 { font-size: clamp(3rem, 8vw, 5rem); font-weight: 800; margin-bottom: 1rem;
-      background: linear-gradient(45deg, #fff, #e0e6ff); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+      background: linear-gradient(45deg, #fff, #e0e6ff); background-clip: text; color: transparent;
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
     .hero p { font-size: 1.3rem; margin-bottom: 2rem; opacity: 0.95; }
     .cta-buttons { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
     .btn { padding: 0.9rem 1.4rem; border: none; border-radius: 999px; font-size: 1rem; font-weight: 700; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease; text-decoration: none; display: inline-block; }


### PR DESCRIPTION
## Summary
- ensure the hero heading gradient uses standard `background-clip: text` with a transparent color fallback
- retain the existing WebKit-prefixed properties for Safari support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da6ba18b2c832882bb59b4718460f0